### PR TITLE
Create README.md with documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+<img src="https://camo.githubusercontent.com/d5b066d1acdf22209876bd84d01cfd86a3a223fa8518a1c699323e91215b5ecf/68747470733a2f2f64357a6d736f663134326633362e636c6f756466726f6e742e6e65742f696d616765732f76757a69782d6c6f676f2e706e67">
+
+
+## SpeechRecognitionService
+<a href="https://vuzix-website.s3.amazonaws.com/files/Content/Upload/sdk-speechrecognitionservice-javadoc-1.5_v2.zip">Documentation</a>


### PR DESCRIPTION
After searching for hours, I found the documentation link on a StackOverflow question (https://stackoverflow.com/questions/60778715/vuzix-speech-sdk-language-support).
It would be way easier for developers to have the link of the documentation inside the README file of this repo.